### PR TITLE
filter hidden (dot) files

### DIFF
--- a/src/library_scene.c
+++ b/src/library_scene.c
@@ -56,7 +56,7 @@ void PGB_LibraryScene_listFiles(const char *filename, void *userdata) {
     }
     extension = dot + 1;
     
-    if(strcmp(extension, "gb") == 0 || strcmp(extension, "gbc") == 0){
+    if((strcmp(extension, "gb") == 0 || strcmp(extension, "gbc") == 0) && strncmp(filename, ".", 1) != 0){
         PGB_Game *game = PGB_Game_new(filename);
         array_push(libraryScene->games, game);
     }


### PR DESCRIPTION
Some operating systems will also add a hidden file (for various reason), and dot files are a pretty standard way to make them hidden. This filters out all files that begin with `.` and end with a valid rom extension.