### PR TITLE
Optimize: Apply Ofast/O3 to key emulation and app functions

### DIFF
--- a/minigb_apu/minigb_apu.c
+++ b/minigb_apu/minigb_apu.c
@@ -117,6 +117,7 @@ static void chan_enable(const uint_fast8_t i, const bool enable)
 	//audio_mem[0xFF26 - AUDIO_ADDR_COMPENSATION] |= 0x80 | ((uint8_t)enable) << i;
 }
 
+__attribute__((optimize("Ofast")))
 static void update_env(struct chan *c)
 {
 	c->env.counter += c->env.inc;

--- a/peanut_gb/peanut_gb.h
+++ b/peanut_gb/peanut_gb.h
@@ -534,6 +534,7 @@ void gb_set_rtc(struct gb_s *gb, const struct tm * const time)
 /**
  * Internal function used to read bytes.
  */
+__attribute__((optimize("O3")))
 uint8_t __gb_read(struct gb_s *gb, const uint_fast16_t addr)
 {
 	switch(addr >> 12)
@@ -3707,6 +3708,7 @@ void __gb_step_cpu(struct gb_s *gb)
     }
 }
 
+__attribute__((optimize("Ofast")))
 void gb_run_frame(struct gb_s *gb)
 {
 	gb->gb_frame = 0;

--- a/src/app.c
+++ b/src/app.c
@@ -45,6 +45,7 @@ void PGB_init(void)
     PGB_present(libraryScene->scene);
 }
 
+__attribute__((optimize("Ofast")))
 void PGB_update(float dt)
 {
     PGB_App->dt = dt;


### PR DESCRIPTION
Applied targeted compiler optimizations to improve performance in critical areas:

- `minigb_apu.c`:
    - `update_env()`: Ofast
- `peanut_gb.h`:
    - `__gb_read()`: O3
    - `gb_run_frame()`: Ofast
- `src/app.c`:
    - `PGB_update()`: Ofast

These changes aim to enhance runtime speed of core emulation and application update loops.